### PR TITLE
Improve mobile nav and hero CTA

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -203,6 +203,14 @@ export default function Container(props: ContainerProps) {
           ))}
         </ul>
 
+        {/* Hide contact on mobile to avoid overlapping the hamburger menu */}
+        <Link
+          href="/contact"
+          className="hidden px-4 py-2 text-sm md:inline-block"
+        >
+          Contact
+        </Link>
+
         <Link
           href="https://calendly.com/metaswapllc/30min"
           className="hidden rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 sm:inline-flex"
@@ -237,7 +245,7 @@ export default function Container(props: ContainerProps) {
               </div>
               <div className="flex h-full flex-col items-start justify-between overflow-y-auto">
                 {/* Links */}
-                <ul className="flex min-h-fit w-full flex-col items-start space-y-6 px-[22px] py-[58px]">
+                <ul className="flex min-h-fit w-full flex-col items-start space-y-6 px-4 py-6">
                   {navLinks.map((link, i) => (
                     <button key={link.href} onClick={() => setIsOpen(false)}>
                       <NavItem
@@ -249,8 +257,15 @@ export default function Container(props: ContainerProps) {
                     </button>
                   ))}
                   <Link
+                    href="/contact"
+                    className="text-xl"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    Contact
+                  </Link>
+                  <Link
                     href="https://calendly.com/metaswapllc/30min"
-                    className="mt-6 inline-flex rounded-md bg-primary px-4 py-2 text-primary-foreground"
+                    className="w-full rounded-md bg-primary px-4 py-3 text-center text-primary-foreground"
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,16 @@
+import Container from "@/components/Container";
+
+export default function Contact() {
+  return (
+    <Container title="Contact">
+      <section className="flex min-h-screen flex-col items-center justify-center space-y-6 text-center">
+        <h1 className="text-5xl font-semibold tracking-tighter">
+          Get in Touch
+        </h1>
+        <p className="max-w-xl text-lg text-muted-foreground">
+          Reach out to our team for any questions or inquiries.
+        </p>
+      </section>
+    </Container>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -96,9 +96,9 @@ export default function Home() {
           <p data-scroll data-scroll-enable-touch-speed data-scroll-speed=".06" className="mx-auto max-w-2xl text-lg tracking-tight text-muted-foreground 2xl:text-xl">
             Metaswap Labs helps businesses save time, grow revenue, and scale operations through plug-and-play automation systems.
           </p>
-          <div className="flex flex-col items-center justify-center space-y-4 pt-6 sm:flex-row sm:space-x-4 sm:space-y-0">
+          <div className="flex flex-col items-center text-center px-4">
             <Link href="https://calendly.com/metaswapllc/30min" passHref>
-              <button className="w-full rounded-md bg-primary px-6 py-3 text-primary-foreground sm:w-auto">
+              <button className="mt-6 px-6 py-3 rounded-md bg-metaswapBlue text-black font-semibold shadow-md hover:bg-opacity-90 transition">
                 Get Automated <ChevronRight className="ml-1 h-4 w-4" />
               </button>
             </Link>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -49,6 +49,7 @@ const config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        metaswapBlue: "#7B82FE",
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- hide contact link on mobile in the header
- style mobile drawer navigation spacing
- update hero CTA spacing on the homepage
- add placeholder contact page
- define `metaswapBlue` Tailwind color

## Testing
- `npm run lint`
- `npm run type-check`
